### PR TITLE
Add investment horizon slider with compounding curve display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>中国A股策略目标面板</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">阶段一 · 战略目标与约束</p>
+          <h1>中国A股分析闭环 · 策略航标</h1>
+          <p class="subtitle">
+            聚焦1-3年投资周期，以科技驱动成长为主轴。在此面板中可快速浏览收益、风险、行业配置和风控红线，作为后续Agent体系建设的起点。
+          </p>
+        </div>
+        <div class="scenario-switcher" role="group" aria-label="市场情景切换">
+          <button class="scenario-button is-active" data-scenario="bull">
+            牛市场景
+          </button>
+          <button class="scenario-button" data-scenario="bear">熊市场景</button>
+        </div>
+      </header>
+
+      <section class="grid">
+        <article class="card span-2" id="objectives-card">
+          <header class="card__header">
+            <h2>核心收益目标</h2>
+            <span class="tag">1-3年周期</span>
+          </header>
+          <div class="card__body">
+            <dl class="metric-list">
+              <div class="metric">
+                <dt>目标年化收益率（CAGR）</dt>
+                <dd><span id="target-cagr">50%</span></dd>
+              </div>
+              <div class="metric">
+                <dt>投资期限</dt>
+                <dd><span id="investment-duration-display">3年</span></dd>
+              </div>
+              <div class="metric">
+                <dt>参考时间范围</dt>
+                <dd>滚动评估，每月复盘</dd>
+              </div>
+              <div class="metric">
+                <dt>策略主线</dt>
+                <dd>科技驱动成长（机器人优先）</dd>
+              </div>
+            </dl>
+            <form class="tuning-form" aria-label="调整核心收益目标">
+              <div class="tuning-control">
+                <label for="cagr-slider">调整目标年化收益率</label>
+                <div class="tuning-control__input">
+                  <input
+                    type="range"
+                    id="cagr-slider"
+                    name="cagr-slider"
+                    min="10"
+                    max="80"
+                    step="5"
+                    value="50"
+                  />
+                  <output id="cagr-slider-output" for="cagr-slider">50%</output>
+                </div>
+              </div>
+              <div class="tuning-control">
+                <label for="duration-slider">投资期限（年）</label>
+                <div class="tuning-control__input">
+                  <input
+                    type="range"
+                    id="duration-slider"
+                    name="duration-slider"
+                    min="1"
+                    max="3"
+                    step="1"
+                    value="3"
+                  />
+                  <output id="duration-slider-output" for="duration-slider">3年</output>
+                </div>
+              </div>
+            </form>
+            <section class="growth-visual" aria-labelledby="growth-chart-title">
+              <header class="growth-visual__header">
+                <p class="growth-visual__title" id="growth-chart-title">复利收益曲线</p>
+                <p class="growth-visual__subtitle">以100为基准本金，按月复利</p>
+              </header>
+              <svg
+                class="growth-chart"
+                id="growth-chart"
+                viewBox="0 0 280 160"
+                role="img"
+                aria-describedby="growth-chart-caption"
+                preserveAspectRatio="none"
+              >
+                <path class="growth-chart__area" data-role="area" d="" />
+                <path class="growth-chart__line" data-role="line" d="" />
+              </svg>
+              <p class="growth-visual__footer" id="growth-chart-caption">
+                终值（含复利）：<span id="growth-end-value">100</span>
+              </p>
+            </section>
+          </div>
+        </article>
+
+        <article class="card">
+          <header class="card__header">
+            <h2>风险承受度</h2>
+          </header>
+          <div class="card__body">
+            <dl class="metric-list">
+              <div class="metric">
+                <dt>最大可接受回撤</dt>
+                <dd>30%</dd>
+              </div>
+              <div class="metric">
+                <dt>波动容忍度</dt>
+                <dd>高波动可接受（年轻且有被动收入）</dd>
+              </div>
+              <div class="metric">
+                <dt>政策风险态度</dt>
+                <dd>低容忍度，触发即启动专项分析</dd>
+              </div>
+            </dl>
+          </div>
+        </article>
+
+        <article class="card" id="allocation-card">
+          <header class="card__header">
+            <h2>仓位与行业权重</h2>
+          </header>
+          <div class="card__body">
+            <dl class="metric-list">
+              <div class="metric">
+                <dt>总体仓位</dt>
+                <dd><span id="target-exposure">90%</span></dd>
+              </div>
+              <div class="metric">
+                <dt>科技行业权重</dt>
+                <dd><span id="tech-allocation">100%</span></dd>
+              </div>
+              <div class="metric">
+                <dt>科技内部配置</dt>
+                <dd id="tech-breakdown">机器人50% / 半导体40% / 软件10%</dd>
+              </div>
+            </dl>
+            <form class="tuning-form" aria-label="调整仓位与行业配置">
+              <div class="tuning-control">
+                <label for="exposure-slider">调整目标仓位</label>
+                <div class="tuning-control__input">
+                  <input
+                    type="range"
+                    id="exposure-slider"
+                    name="exposure-slider"
+                    min="0"
+                    max="100"
+                    step="5"
+                    value="90"
+                  />
+                  <output id="exposure-slider-output" for="exposure-slider">90%</output>
+                </div>
+              </div>
+              <div class="tuning-control">
+                <label for="tech-weight-slider">科技行业在组合中的权重</label>
+                <div class="tuning-control__input">
+                  <input
+                    type="range"
+                    id="tech-weight-slider"
+                    name="tech-weight-slider"
+                    min="0"
+                    max="100"
+                    step="5"
+                    value="100"
+                  />
+                  <output id="tech-weight-output" for="tech-weight-slider">100%</output>
+                </div>
+              </div>
+              <div class="tuning-control">
+                <label for="robotics-slider">机器人板块占科技仓位</label>
+                <div class="tuning-control__input tuning-control__input--split">
+                  <input
+                    type="range"
+                    id="robotics-slider"
+                    name="robotics-slider"
+                    min="0"
+                    max="100"
+                    step="5"
+                    value="50"
+                  />
+                  <output id="robotics-output" for="robotics-slider">50%</output>
+                </div>
+              </div>
+              <div class="tuning-control">
+                <label for="semiconductor-slider">半导体板块占科技仓位</label>
+                <div class="tuning-control__input tuning-control__input--split">
+                  <input
+                    type="range"
+                    id="semiconductor-slider"
+                    name="semiconductor-slider"
+                    min="0"
+                    max="50"
+                    step="5"
+                    value="40"
+                  />
+                  <output id="semiconductor-output" for="semiconductor-slider">40%</output>
+                </div>
+              </div>
+              <p class="tuning-note">
+                软件板块自动占据剩余<span id="software-output">10%</span>科技仓位。
+              </p>
+            </form>
+          </div>
+        </article>
+
+        <article class="card span-2">
+          <header class="card__header">
+            <h2>宏观判断要素</h2>
+          </header>
+          <div class="card__body">
+            <ul class="signal-list">
+              <li>
+                <span class="signal__title">股债收益差</span>
+                <span class="signal__desc">股市盈利率 - 国债收益率，越高越利好权益</span>
+              </li>
+              <li>
+                <span class="signal__title">社融-M2剪刀差</span>
+                <span class="signal__desc">社融增速高于名义GDP且M2走扩 → 牛市土壤</span>
+              </li>
+              <li>
+                <span class="signal__title">央行基准利率</span>
+                <span class="signal__desc">降息或宽松信号有利于A股估值扩张</span>
+              </li>
+              <li>
+                <span class="signal__title">杠杆资金情绪</span>
+                <span class="signal__desc">融资余额见底回升代表资金回流</span>
+              </li>
+              <li>
+                <span class="signal__title">北向资金净流入</span>
+                <span class="signal__desc">持续净流入意味着外资看多中国资产</span>
+              </li>
+              <li>
+                <span class="signal__title">经济周期指标</span>
+                <span class="signal__desc">PMI > 50、盈利周期上行支撑牛市判断</span>
+              </li>
+              <li>
+                <span class="signal__title">成交额与换手率</span>
+                <span class="signal__desc">成交活跃、换手提升印证风险偏好</span>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="card span-2">
+          <header class="card__header">
+            <h2>政策与风控红线</h2>
+            <span class="tag tag--alert">触发即需人工确认</span>
+          </header>
+          <div class="card__body">
+            <ul class="signal-list">
+              <li>
+                <span class="signal__title">监管环境收紧</span>
+                <span class="signal__desc">涉及核心赛道的监管升级时，立即启动专项分析</span>
+              </li>
+              <li>
+                <span class="signal__title">补贴或激励退坡</span>
+                <span class="signal__desc">评估盈利假设与估值模型是否失效</span>
+              </li>
+              <li>
+                <span class="signal__title">重大负面舆情</span>
+                <span class="signal__desc">资讯Agent标记并推动风控流程，等待人工确认</span>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="card span-2">
+          <header class="card__header">
+            <h2>AI Agent 协作边界</h2>
+          </header>
+          <div class="card__body">
+            <ul class="signal-list">
+              <li>
+                <span class="signal__title">自主执行</span>
+                <span class="signal__desc">数据采集、模型搭建、估值与回测由Agent全权处理</span>
+              </li>
+              <li>
+                <span class="signal__title">共识决策</span>
+                <span class="signal__desc">宏观研判与关键因子选择需与投资者沟通后定稿</span>
+              </li>
+              <li>
+                <span class="signal__title">审计记录</span>
+                <span class="signal__desc">所有自动动作与假设变更纳入月度合并日志</span>
+              </li>
+            </ul>
+          </div>
+        </article>
+      </section>
+
+      <footer class="footer">
+        <p>
+          下一步：在此战略基线之上，规划宏观与行业Agent的数据方案与分析链路。
+        </p>
+      </footer>
+    </main>
+
+    <script src="scripts/app.js" defer></script>
+  </body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,267 @@
+const SCENARIOS = {
+  bull: {
+    cagr: 50,
+    duration: 3,
+    exposure: 90,
+    techAllocation: 100,
+    breakdown: {
+      robotics: 50,
+      semiconductors: 40,
+      software: 10
+    },
+    description:
+      '高速成长阶段，以机器人为核心主线，半导体与软件协同放大弹性。'
+  },
+  bear: {
+    cagr: 15,
+    duration: 3,
+    exposure: 30,
+    techAllocation: 20,
+    breakdown: {
+      robotics: 10,
+      semiconductors: 80,
+      software: 10
+    },
+    description:
+      '防守状态下聚焦核心确定性资产，压缩仓位并保持科技底仓以等待反转。'
+  }
+};
+
+function cloneScenario(data) {
+  return {
+    cagr: data.cagr,
+    duration: data.duration,
+    exposure: data.exposure,
+    techAllocation: data.techAllocation,
+    breakdown: { ...data.breakdown },
+    description: data.description
+  };
+}
+
+const state = {
+  bull: cloneScenario(SCENARIOS.bull),
+  bear: cloneScenario(SCENARIOS.bear)
+};
+
+const targetCagrEl = document.querySelector('#target-cagr');
+const investmentDurationEl = document.querySelector('#investment-duration-display');
+const targetExposureEl = document.querySelector('#target-exposure');
+const techAllocationEl = document.querySelector('#tech-allocation');
+const techBreakdownEl = document.querySelector('#tech-breakdown');
+const scenarioButtons = document.querySelectorAll('.scenario-button');
+
+const cagrSlider = document.querySelector('#cagr-slider');
+const cagrOutput = document.querySelector('#cagr-slider-output');
+const durationSlider = document.querySelector('#duration-slider');
+const durationOutput = document.querySelector('#duration-slider-output');
+const exposureSlider = document.querySelector('#exposure-slider');
+const exposureOutput = document.querySelector('#exposure-slider-output');
+const techWeightSlider = document.querySelector('#tech-weight-slider');
+const techWeightOutput = document.querySelector('#tech-weight-output');
+const roboticsSlider = document.querySelector('#robotics-slider');
+const roboticsOutput = document.querySelector('#robotics-output');
+const semiconductorSlider = document.querySelector('#semiconductor-slider');
+const semiconductorOutput = document.querySelector('#semiconductor-output');
+const softwareOutput = document.querySelector('#software-output');
+const growthChart = document.querySelector('#growth-chart');
+const growthLine = growthChart ? growthChart.querySelector('[data-role="line"]') : null;
+const growthArea = growthChart ? growthChart.querySelector('[data-role="area"]') : null;
+const growthEndValue = document.querySelector('#growth-end-value');
+
+const scenarioDescription = document.createElement('p');
+scenarioDescription.className = 'scenario-description';
+scenarioDescription.textContent = SCENARIOS.bull.description;
+
+const objectivesBody = document.querySelector('#objectives-card .card__body');
+if (objectivesBody) {
+  objectivesBody.appendChild(scenarioDescription);
+}
+
+let activeScenario = 'bull';
+
+function formatPercent(value) {
+  return `${Math.round(value)}%`;
+}
+
+function formatYears(value) {
+  return `${value}年`;
+}
+
+function updateBreakdownView(breakdown) {
+  const robotics = Math.round(breakdown.robotics);
+  const semiconductors = Math.round(breakdown.semiconductors);
+  const software = Math.max(0, 100 - robotics - semiconductors);
+
+  roboticsOutput.textContent = formatPercent(robotics);
+  semiconductorOutput.textContent = formatPercent(semiconductors);
+  softwareOutput.textContent = formatPercent(software);
+  techBreakdownEl.textContent = `机器人${robotics}% / 半导体${semiconductors}% / 软件${software}%`;
+}
+
+function clampBreakdown() {
+  let robotics = Number(roboticsSlider.value);
+  let semiconductors = Number(semiconductorSlider.value);
+
+  if (robotics > 100 - semiconductors) {
+    robotics = 100 - semiconductors;
+    roboticsSlider.value = robotics;
+  }
+
+  if (semiconductors > 100 - robotics) {
+    semiconductors = 100 - robotics;
+    semiconductorSlider.value = semiconductors;
+  }
+
+  roboticsSlider.max = 100 - semiconductors;
+  semiconductorSlider.max = 100 - robotics;
+
+  const software = Math.max(0, 100 - robotics - semiconductors);
+
+  state[activeScenario].breakdown = {
+    robotics,
+    semiconductors,
+    software
+  };
+
+  updateBreakdownView(state[activeScenario].breakdown);
+}
+
+function updateGrowthChart() {
+  if (!growthChart || !growthLine || !growthArea || !growthEndValue) {
+    return;
+  }
+
+  const { cagr, duration } = state[activeScenario];
+  const years = Math.max(1, duration);
+  const rate = Math.max(0, cagr) / 100;
+  const baseCapital = 100;
+  const width = 280;
+  const height = 160;
+  const paddingTop = 16;
+  const paddingBottom = 20;
+  const usableHeight = height - paddingTop - paddingBottom;
+  const steps = Math.max(12, years * 12);
+  const finalValue = baseCapital * Math.pow(1 + rate, years);
+  const maxValue = Math.max(baseCapital, finalValue);
+
+  const points = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const ratio = i / steps;
+    const time = ratio * years;
+    const amount = baseCapital * Math.pow(1 + rate, time);
+    const x = ratio * width;
+    const normalised = maxValue === baseCapital ? 0 : (amount - baseCapital) / (maxValue - baseCapital);
+    const y = height - paddingBottom - normalised * usableHeight;
+    points.push({ x, y });
+  }
+
+  let linePath = '';
+  points.forEach((point, index) => {
+    const command = index === 0 ? 'M' : 'L';
+    linePath += `${command}${point.x.toFixed(2)} ${point.y.toFixed(2)} `;
+  });
+
+  const baseline = height - paddingBottom;
+  let areaPath = `M0 ${baseline.toFixed(2)} `;
+  points.forEach((point) => {
+    areaPath += `L${point.x.toFixed(2)} ${point.y.toFixed(2)} `;
+  });
+  areaPath += `L${width.toFixed(2)} ${baseline.toFixed(2)} Z`;
+
+  growthLine.setAttribute('d', linePath.trim());
+  growthArea.setAttribute('d', areaPath.trim());
+  growthEndValue.textContent = finalValue.toFixed(1);
+}
+
+function applyScenario(mode) {
+  activeScenario = mode;
+  const data = state[mode];
+
+  targetCagrEl.textContent = formatPercent(data.cagr);
+  investmentDurationEl.textContent = formatYears(data.duration);
+  targetExposureEl.textContent = formatPercent(data.exposure);
+  techAllocationEl.textContent = formatPercent(data.techAllocation);
+  updateBreakdownView(data.breakdown);
+
+  cagrSlider.value = data.cagr;
+  cagrOutput.textContent = formatPercent(data.cagr);
+  durationSlider.value = data.duration;
+  durationOutput.textContent = formatYears(data.duration);
+  exposureSlider.value = data.exposure;
+  exposureOutput.textContent = formatPercent(data.exposure);
+  techWeightSlider.value = data.techAllocation;
+  techWeightOutput.textContent = formatPercent(data.techAllocation);
+  roboticsSlider.value = data.breakdown.robotics;
+  semiconductorSlider.value = data.breakdown.semiconductors;
+
+  clampBreakdown();
+
+  scenarioDescription.textContent = data.description;
+
+  updateGrowthChart();
+
+  scenarioButtons.forEach((btn) => {
+    btn.classList.toggle('is-active', btn.dataset.scenario === mode);
+  });
+}
+
+scenarioButtons.forEach((button) => {
+  button.addEventListener('click', () => applyScenario(button.dataset.scenario));
+});
+
+cagrSlider.addEventListener('input', () => {
+  const value = Number(cagrSlider.value);
+  state[activeScenario].cagr = value;
+  targetCagrEl.textContent = formatPercent(value);
+  cagrOutput.textContent = formatPercent(value);
+  updateGrowthChart();
+});
+
+durationSlider.addEventListener('input', () => {
+  const value = Number(durationSlider.value);
+  state[activeScenario].duration = value;
+  investmentDurationEl.textContent = formatYears(value);
+  durationOutput.textContent = formatYears(value);
+  updateGrowthChart();
+});
+
+exposureSlider.addEventListener('input', () => {
+  const value = Number(exposureSlider.value);
+  state[activeScenario].exposure = value;
+  targetExposureEl.textContent = formatPercent(value);
+  exposureOutput.textContent = formatPercent(value);
+});
+
+techWeightSlider.addEventListener('input', () => {
+  const value = Number(techWeightSlider.value);
+  state[activeScenario].techAllocation = value;
+  techAllocationEl.textContent = formatPercent(value);
+  techWeightOutput.textContent = formatPercent(value);
+});
+
+roboticsSlider.addEventListener('input', () => {
+  clampBreakdown();
+});
+
+semiconductorSlider.addEventListener('input', () => {
+  clampBreakdown();
+});
+
+const prefersDark =
+  window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+const body = document.body;
+
+function updateTheme() {
+  if (prefersDark.matches) {
+    body.classList.add('dark');
+  } else {
+    body.classList.remove('dark');
+  }
+}
+
+if (prefersDark) {
+  prefersDark.addEventListener('change', updateTheme);
+  updateTheme();
+}
+
+applyScenario(activeScenario);

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,350 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fa;
+  --bg-dark: #111827;
+  --card: rgba(255, 255, 255, 0.82);
+  --card-dark: rgba(17, 24, 39, 0.82);
+  --border: rgba(15, 23, 42, 0.08);
+  --border-dark: rgba(148, 163, 184, 0.2);
+  --text: #0f172a;
+  --text-secondary: #334155;
+  --text-muted: #64748b;
+  --accent: #2563eb;
+  --accent-muted: rgba(37, 99, 235, 0.12);
+  --alert: #dc2626;
+  --shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'PingFang SC',
+    'Microsoft YaHei', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--bg), #dbeafe 65%);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2.5rem 1.5rem 3.5rem;
+}
+
+body.dark {
+  background: linear-gradient(135deg, #020617, #0f172a 70%);
+  color: #e2e8f0;
+}
+
+.layout {
+  max-width: 1100px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  font-weight: 700;
+  color: var(--text);
+}
+
+.eyebrow {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  max-width: 42rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  font-size: 0.98rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  position: relative;
+  border-radius: 20px;
+  padding: 1.5rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+body.dark .card {
+  background: var(--card-dark);
+  border-color: var(--border-dark);
+  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.6);
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.14);
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.card__header h2 {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.tag {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: var(--accent-muted);
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.tag--alert {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--alert);
+}
+
+.metric-list {
+  display: grid;
+  gap: 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.metric dt {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.metric dd {
+  margin-left: 0;
+  color: var(--text-secondary);
+}
+
+.metric span {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.tuning-form {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.tuning-control {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.tuning-control label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.tuning-control__input {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.tuning-control__input input[type='range'] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.tuning-control__input output {
+  min-width: 3.5rem;
+  text-align: right;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.tuning-control__input--split output {
+  min-width: 4rem;
+}
+
+.tuning-note {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.growth-visual {
+  margin-top: 1.5rem;
+  padding: 1.25rem 1.35rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: rgba(37, 99, 235, 0.06);
+  display: grid;
+  gap: 0.75rem;
+}
+
+body.dark .growth-visual {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(96, 165, 250, 0.32);
+}
+
+.growth-visual__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.growth-visual__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.growth-visual__subtitle {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.growth-chart {
+  width: 100%;
+  height: 160px;
+}
+
+.growth-chart__line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.growth-chart__area {
+  fill: rgba(37, 99, 235, 0.16);
+  stroke: none;
+}
+
+body.dark .growth-chart__area {
+  fill: rgba(96, 165, 250, 0.24);
+}
+
+.growth-visual__footer {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.growth-visual__footer span {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.scenario-description {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--accent);
+  font-size: 0.93rem;
+  line-height: 1.5;
+}
+
+.signal-list {
+  display: grid;
+  gap: 0.85rem;
+  list-style: none;
+  color: var(--text-secondary);
+}
+
+.signal__title {
+  display: block;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.15rem;
+}
+
+.signal__desc {
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.scenario-switcher {
+  display: inline-flex;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.scenario-button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.scenario-button.is-active {
+  background: var(--accent);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  padding: 1.5rem 0;
+}
+
+.span-2 {
+  grid-column: span 2;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .span-2 {
+    grid-column: span 1;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #020617;
+    --card: rgba(15, 23, 42, 0.72);
+    --text: #e2e8f0;
+    --text-secondary: #cbd5f5;
+    --border: rgba(51, 65, 85, 0.35);
+    --text-muted: #94a3b8;
+  }
+}


### PR DESCRIPTION
## Summary
- add an adjustable investment horizon slider tied to scenario-specific targets alongside the CAGR control
- render a minimalist compounding growth curve that reacts to CAGR and horizon inputs and surfaces the compounded terminal value
- style the new duration control and chart area to match the existing glassmorphism dashboard aesthetic

## Testing
- not run (static assets only)

------
https://chatgpt.com/codex/tasks/task_e_68d730e20b10832283cd3beb3a7b1809